### PR TITLE
fix: call Observable.share() to avoid extra side effects

### DIFF
--- a/src/config.loader.ts
+++ b/src/config.loader.ts
@@ -5,6 +5,7 @@ import { Http } from '@angular/http';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/reduce';
 import 'rxjs/add/operator/mergeMap';
+import 'rxjs/add/operator/share';
 import 'rxjs/add/operator/toPromise';
 import { Observable } from 'rxjs';
 import * as _ from 'lodash';
@@ -55,7 +56,8 @@ export class ConfigMergedLoader implements ConfigLoader {
     };
     const jsons = Observable.onErrorResumeNext(this.paths.map(path => this.http.get(path)))
       .map((res: any) => res.json())
-      .filter((x: any) => x !== null);
+      .filter((x: any) => x !== null)
+      .share();
     return jsons.merge(errorIfEmpty(jsons))
       .reduce((x: any, y: any) => mergeWith(x, y), {})
       .toPromise()


### PR DESCRIPTION
Without this call, the first element of `paths` will be requested (via
http) twice.

reference:
https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/share.md